### PR TITLE
fix return position in regionfuse.py

### DIFF
--- a/AIPUBuilder/Optimizer/ops/regionfuse.py
+++ b/AIPUBuilder/Optimizer/ops/regionfuse.py
@@ -120,12 +120,12 @@ def regionfuse(self, *args):
                 fuse_ps += num_perclass1
                 out_num_perclass[b][i] = num_perclass0 + num_perclass1
 
-        self.outputs[0].betensor = out_score
-        self.outputs[1].betensor = out_box
-        self.outputs[2].betensor = out_num_perclass
-        self.outputs[3].betensor = out_label
-        self.outputs[4].betensor = out_total_class_num
-        return [o.betensor for o in self.outputs]
+    self.outputs[0].betensor = out_score
+    self.outputs[1].betensor = out_box
+    self.outputs[2].betensor = out_num_perclass
+    self.outputs[3].betensor = out_label
+    self.outputs[4].betensor = out_total_class_num
+    return [o.betensor for o in self.outputs]
 
 
 @quant_register(OpType.RegionFuse)


### PR DESCRIPTION
I move the "return"  out of   the  "for loop " of batch_size. 

![image](https://github.com/Arm-China/Compass_Optimizer/assets/95006218/21660e4a-76fc-4ec6-8962-24c9ff6cf55d)


 